### PR TITLE
create basic end-to-end flow and structure for private topics

### DIFF
--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -113,6 +113,8 @@
 	"thread-tools.markAsUnreadForAll": "Mark Unread For All",
 	"thread-tools.pin": "Pin Topic",
 	"thread-tools.unpin": "Unpin Topic",
+	"thread-tools.private": "Private Topic",
+	"thread-tools.unprivate": "Public Topic",
 	"thread-tools.lock": "Lock Topic",
 	"thread-tools.unlock": "Unlock Topic",
 	"thread-tools.move": "Move Topic",

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -100,6 +100,8 @@
     "thread-tools.markAsUnreadForAll": "Mark Unread For All",
     "thread-tools.pin": "Pin Topic",
     "thread-tools.unpin": "Unpin Topic",
+    "thread-tools.private": "Private Topic",
+    "thread-tools.unprivate": "Public Topic",
     "thread-tools.lock": "Lock Topic",
     "thread-tools.unlock": "Unlock Topic",
     "thread-tools.move": "Move Topic",

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -234,6 +234,9 @@ TopicObjectSlim:
           type: number
           description: Whether or not this particular topic is pinned to the top of the
             category
+        private:
+          type: number
+          description: Whether this topic is private or public
         timestamp:
           type: number
         timestampISO:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -148,6 +148,8 @@ paths:
     $ref: 'write/topics/tid/lock.yaml'
   /topics/{tid}/pin:
     $ref: 'write/topics/tid/pin.yaml'
+  /topics/{tid}/private:
+    $ref: 'write/topics/tid/private.yaml'
   /topics/{tid}/follow:
     $ref: 'write/topics/tid/follow.yaml'
   /topics/{tid}/ignore:

--- a/public/openapi/write/topics/tid/private.yaml
+++ b/public/openapi/write/topics/tid/private.yaml
@@ -1,0 +1,52 @@
+put:
+  tags:
+    - topics
+  summary: make a topic private
+  description: This operation makes a topic private.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully made private.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+delete:
+  tags:
+    - topics
+  summary: make a topic public (unprivate)
+  description: This operation makes a private topic public.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully made public
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -134,6 +134,8 @@ define('forum/category/tools', [
 		socket.on('event:topic_purged', onTopicPurged);
 		socket.on('event:topic_locked', setLockedState);
 		socket.on('event:topic_unlocked', setLockedState);
+		socket.on('event:topic_private', setPrivateState);
+		socket.on('event:topic_unprivate', setPrivateState);
 		socket.on('event:topic_pinned', setPinnedState);
 		socket.on('event:topic_unpinned', setPinnedState);
 		socket.on('event:topic_moved', onTopicMoved);
@@ -182,6 +184,8 @@ define('forum/category/tools', [
 		socket.removeListener('event:topic_unlocked', setLockedState);
 		socket.removeListener('event:topic_pinned', setPinnedState);
 		socket.removeListener('event:topic_unpinned', setPinnedState);
+		socket.removeListener('event:topic_private', setPrivateState);
+		socket.removeListener('event:topic_unprivate', setPrivateState);
 		socket.removeListener('event:topic_moved', onTopicMoved);
 	};
 
@@ -253,6 +257,10 @@ define('forum/category/tools', [
 		return getTopicEl(tid).hasClass('locked');
 	}
 
+	// function isTopicPrivate(tid) {
+	// return getTopicEl(tid).hasClass('private');
+	// }
+
 	function isTopicPinned(tid) {
 		return getTopicEl(tid).hasClass('pinned');
 	}
@@ -269,6 +277,13 @@ define('forum/category/tools', [
 		const topic = getTopicEl(data.tid);
 		topic.toggleClass('deleted', data.isDeleted);
 		topic.find('[component="topic/locked"]').toggleClass('hidden', !data.isDeleted);
+	}
+
+	function setPrivateState(data) {
+		const topic = getTopicEl(data.tid);
+		topic.toggleClass('private', data.isPrivate);
+		topic.find('[component="topic/private"]').toggleClass('hidden', !data.isPrivate);
+		ajaxify.refresh();
 	}
 
 	function setPinnedState(data) {

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -26,6 +26,9 @@ define('forum/topic/events', [
 		'event:topic_locked': threadTools.setLockedState,
 		'event:topic_unlocked': threadTools.setLockedState,
 
+		'event:topic_private': threadTools.setPrivateState,
+		'event:topic_unprivate': threadTools.setPrivateState,
+
 		'event:topic_pinned': threadTools.setPinnedState,
 		'event:topic_unpinned': threadTools.setPinnedState,
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -51,11 +51,21 @@ define('forum/topic/threadTools', [
 			return false;
 		});
 
+		topicContainer.on('click', '[component="topic/private"]', function () {
+			topicCommand('put', '/private', 'private');
+			return false;
+		});
+
+		topicContainer.on('click', '[component="topic/unprivate"]', function () {
+			topicCommand('del', '/private', 'unprivate');
+			return false;
+		});
+
 		topicContainer.on('click', '[component="topic/pin"]', function () {
 			topicCommand('put', '/pin', 'pin');
 			return false;
 		});
-
+  
 		topicContainer.on('click', '[component="topic/unpin"]', function () {
 			topicCommand('del', '/pin', 'unpin');
 			return false;
@@ -361,6 +371,21 @@ define('forum/topic/threadTools', [
 
 		threadEl.toggleClass('deleted', data.isDelete);
 		ajaxify.data.deleted = data.isDelete ? 1 : 0;
+
+		posts.addTopicEvents(data.events);
+	};
+
+	ThreadTools.setPrivateState = function (data) {
+		const threadEl = components.get('topic');
+		if (String(data.tid) !== threadEl.attr('data-tid')) {
+			return;
+		}
+		
+		components.get('topic/private').toggleClass('hidden', data.isPrivate).parent().attr('hidden', data.isPrivate ? '' : null);
+		components.get('topic/unprivate').toggleClass('hidden', !data.isPrivate).parent().attr('hidden', !data.isPrivate ? '' : null);
+		const icon = $('[component="topic/labels"] [component="topic/private"]');
+		icon.toggleClass('hidden', !data.isPrivate);
+		ajaxify.data.private = data.isPrivate;
 
 		posts.addTopicEvents(data.events);
 	};

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -146,9 +146,19 @@ topicsAPI.purge = async function (caller, data) {
 	});
 };
 
+topicsAPI.private = async function (caller, { tids }) {
+	await doTopicAction('private', 'event:topic_private', caller, { tids });
+};
+
+topicsAPI.unprivate = async function (caller, { tids }) {
+	await doTopicAction('unprivate', 'event:topic_unprivate', caller, { tids });
+};
+
+
+// here could be when we pin a post
 topicsAPI.pin = async function (caller, { tids, expiry }) {
 	await doTopicAction('pin', 'event:topic_pinned', caller, { tids });
-
+	console.log('here');
 	if (expiry) {
 		await Promise.all(tids.map(async tid => topics.tools.setPinExpiry(tid, expiry, caller.uid)));
 	}

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -79,6 +79,16 @@ Topics.unpin = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Topics.private = async (req, res) => {
+	await api.topics.private(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
+Topics.unprivate = async (req, res) => {
+	await api.topics.unprivate(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
 Topics.lock = async (req, res) => {
 	await api.topics.lock(req, { tids: [req.params.tid] });
 	helpers.formatApiResponse(200, res);

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -174,6 +174,10 @@ privsTopics.canEdit = async function (tid, uid) {
 	return await privsTopics.isOwnerOrAdminOrMod(tid, uid);
 };
 
+privsTopics.canPrivate = async function (tid, uid) {
+	return await privsTopics.isOwnerOrAdminOrMod(tid, uid);
+};
+
 privsTopics.isOwnerOrAdminOrMod = async function (tid, uid) {
 	const [isOwner, isAdminOrMod] = await Promise.all([
 		topics.isOwner(tid, uid),

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -24,6 +24,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
 	setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares], controllers.write.topics.unpin);
 
+	setupApiRoute(router, 'put', '/:tid/private', [...middlewares, middleware.assert.topic], controllers.write.topics.private);
+	setupApiRoute(router, 'delete', '/:tid/private', [...middlewares], controllers.write.topics.unprivate);
+
 	setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
 	setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);
 

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -13,7 +13,7 @@ const intFields = [
 	'viewcount', 'postercount', 'followercount',
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
-	'lastposttime', 'deleterUid',
+	'lastposttime', 'deleterUid', 'private',
 ];
 
 module.exports = function (Topics) {

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -49,6 +49,14 @@ Events._types = {
 		icon: 'fa-trash',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-deleted-topic'),
 	},
+	private: {
+		icon: 'fa-eye-slash',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-made-topic-private'),
+	},
+	unprivate: {
+		icon: 'fa-eye',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-made-topic-public'),
+	},
 	restore: {
 		icon: 'fa-trash-o',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-restored-topic'),

--- a/src/views/partials/topic/topic-menu-list.tpl
+++ b/src/views/partials/topic/topic-menu-list.tpl
@@ -15,6 +15,14 @@
 	<a component="topic/unpin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unpin]]</a>
 </li>
 
+<li {{{ if private }}}hidden{{{ end }}}>
+	<a component="topic/private" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if private }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eye-slash text-secondary"></i> [[topic:thread-tools.private]]</a>
+</li>
+
+<li {{{ if !private }}}hidden{{{ end }}}>
+	<a component="topic/unprivate" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !private }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eye text-secondary"></i> [[topic:thread-tools.unprivate]]</a>
+</li>
+
 <li>
 	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
 </li>


### PR DESCRIPTION
### Related Files
fixes #27 
fixes #10 
related to #11 

### Context
Creating the ability for users to be able to make posts private. The motivation for this change is that for an education forum, it is important to be able to share information privately to both not violate academic integrity but also allow the student to feel comfortable asking questions.

### Description
This task will be accomplished by diving into how pinning topics is currently implemented. This is because making a topic private and making a topic pinned have similar implementation details. The first step is to understand in which files the logic for pinning posts resides and modeling the code changes for making topics private after this. 

### Changes in the codebase
Here are the files that I modified grouped under what functionality they add:

- Add private field to database
    - src/topic/data.js
- Add ability to toggle field in database
    - src/topics/tools.js
- Add permissions for privating
    src/privileges/topics.js
- Define routes/API endpoints
    - src/routes/write/topics/js
- Create controller that handles client requests and server responses
    - src/controllers/write/topics/js
- Implement internal backend functionality
    - src/api/topics.js 
- Create yaml files, api documentation for inputs and outputs
    - public/openapi folder: TopicObject.yaml, write.yaml, private.yaml files
- Add frontend UI changes, including a button/toggle + event handling by ensuring backend changes are propagated to the frontend
    - topic.json files, public/src/client/topic, src/views/partials/topic, public/src/client/category/tools.js, public/src/client/topic/events.js

### Testing Steps

- Created simple frontend UI (since exact incorporation depends on frontend)
- Interacted with the frontend buttons (make private + make public) 
- Checked that changes are persisted in the database using redis cli 
  - redis-cli -h 127.0.0.1 -p 6379 KEYS "topic:*" 
  - redis-cli -h 127.0.0.1 -p 6379 HGET "topic:1" "title"
  - redis-cli -h 127.0.0.1 -p 6379 HGET "topic:1" "private” (this queries the private flag)
- Check that changes are visible on the screen

### Testing Flow and Screenshots
We can see a make private button under topic tools:
<img width="971" height="503" alt="Screenshot 2025-09-26 at 06 43 58" src="https://github.com/user-attachments/assets/e6760bff-3ff4-4269-b398-e029d2406b2b" />
Once this button is pressed (topic is made private), the button changes to "Public" and an indication appears in the thread:
<img width="978" height="422" alt="Screenshot 2025-09-26 at 06 44 15" src="https://github.com/user-attachments/assets/4495743d-714f-4e56-837b-20db5b289202" />
We can check the database to see that the topic is indeed private (indicated by 1):
<img width="1030" height="74" alt="Screenshot 2025-09-26 at 06 45 22" src="https://github.com/user-attachments/assets/a302f595-66a9-484d-b5d0-c731ddba45bf" />
We can make the topic public:
<img width="983" height="557" alt="Screenshot 2025-09-26 at 06 46 48" src="https://github.com/user-attachments/assets/e17e2245-8ea4-4b56-8f30-989b0b736687" />
We can check the database to see that the topic is indeed public (indicated by 0):
<img width="1027" height="64" alt="Screenshot 2025-09-26 at 06 45 44" src="https://github.com/user-attachments/assets/0746ec69-b21d-48e4-8be5-0ad068c7b8b2" />

### Additional information
Currently, only the admin is able to make a topic private. We have to extend this functionality to other users. Additionally, currently, even though a topic is made private, it is still viewable. We should hide the topic based on the permissions.