### PR TITLE
P1B: Broke complex binary expression into more readable control flow

### DIFF
--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -67,10 +67,20 @@ define('forum/topic/posts', [
 			post.display_delete_tools = (ajaxify.data.privileges['posts:delete'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
 			post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 			post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
-			post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
-				(post.selfPost && !ajaxify.data.locked && !post.deleted) ||
-				(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) ||
-				((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted);
+			
+			// Minor refactor; just broke up long binary statement into
+			// multiple shorter ones.
+			post.display_post_menu = false;
+
+			if (ajaxify.data.privileges.isAdminOrMod) {
+				post.display_post_menu = true;
+			} else if (post.selfPost && !ajaxify.data.locked && !post.deleted) {
+				post.display_post_menu = true;
+			} else if (post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) {
+				post.display_post_menu = true;
+			} else if ((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted) {
+				post.display_post_menu = true;
+			}
 		});
 	};
 


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:** [ISSUE](https://github.com/CMU-313/NodeBB/issues/190)

**Full path to the refactored file:** [FILE](https://github.com/crypt0chicken/NodeBB/blob/main/public/src/client/topic/posts.js)

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
I believe this file controls the creation, display, and editing of posts, due to the "Posts.onNewPost()" function running upon creation of a post, the "function createNewPosts()" function (presumably) loading new posts as the user scrolls, and "Posts.modifyPostsByPrivileges()" - the function I modified - controlling what tools a user gets access to.

**What is the scope of your refactoring within that file?**
I modified the "Posts.modifyPostsByPrivileges()" function, specifically Lines 71-72 (now Lines 74-84).

**Which Qlty‑reported issue did you address?**
Complex Binary Expressions in Posts.modifyPostsByPrivileges(), Lines 71-72

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The issue impacted readability, and resolving it makes it easier to understand the conditions under which the post menu is displayed to an admin or user.

**What changes did you make to resolve the issue?**
I converted the long binary expression into a series of if/else statements. The logical flow of the function was left unchanged.

**How do your changes improve adaptability? Did you consider alternatives?**
The if/else statements split up the binary expression into more-readable logic. While I could have used multiple A=(A || B); type statements, I believe if/else accomplishes the goal in a neater, more understandable format.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
By creating a new post or reply, I can trigger "Posts.modifyPostsByPrivileges()" to run, which contains my refactored code.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
Screenshot of trigger before refactoring (Apologies for the messy bookmark toolbar - I'll get around to cleaning it up sometime soon):
<img width="1280" height="764" alt="Triggered_OLD" src="https://github.com/user-attachments/assets/b4931b81-ed1a-40de-8af5-bf29e80c00ec" />

Screenshot of trigger after refactoring (Temporary console.log lines have since been removed):
<img width="1280" height="764" alt="Triggered_REFACTORED" src="https://github.com/user-attachments/assets/58efa569-a843-465b-b8e8-7333e5debd99" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
Screenshot:
<img width="1280" height="764" alt="fewer_smells" src="https://github.com/user-attachments/assets/20ea3ea8-de13-443d-a1f2-67e66c6c1638" />

Qlty output before refactoring:
```
$ qlty smells --no-snippets public/src/client/topic/posts.js
[Initial qlty output omitted]
public/src/client/topic/posts.js
 156  Function with many parameters (count = 5): createNewPosts
  71  Complex binary expression
  72  Complex binary expression
   1  High total complexity (count = 105)
 156  Function with high complexity (count = 29): createNewPosts
 162  Function with high complexity (count = 10): removeAlreadyAddedPosts
 249  Function with high complexity (count = 11): loadMorePosts
 324  Function with high complexity (count = 13): addNecroPostMessage
```

Qlty output after refactoring:
```
$ qlty smells --no-snippets public/src/client/topic/posts.js
[Initial qlty output omitted]
public/src/client/topic/posts.js
 169  Function with many parameters (count = 5): createNewPosts
   1  High total complexity (count = 107)
  61  Function with high complexity (count = 11): modifyPostsByPrivileges
 169  Function with high complexity (count = 29): createNewPosts
 175  Function with high complexity (count = 10): removeAlreadyAddedPosts
 262  Function with high complexity (count = 11): loadMorePosts
 337  Function with high complexity (count = 13): addNecroPostMessage
```
