### PR TITLE
Show "Private" badge on all topic headers, visible on all pages + user account

### DIFF
--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -159,7 +159,7 @@ define('forum/category', [
 		console.log('addPrivateBadgesToTopics called');
 
 		// Add private badge to ALL topics for demo purposes
-		$('[component="category/topic"]').each(function() {
+		$('[component="category/topic"]').each(function () {
 			const topicEl = $(this);
 			const labelsContainer = topicEl.find('[component="topic/labels"]');
 
@@ -174,7 +174,7 @@ define('forum/category', [
 		});
 
 		// Also try adding to any visible watching badges
-		$('[component="topic/watched"]:visible').each(function() {
+		$('[component="topic/watched"]:visible').each(function () {
 			const watchedEl = $(this);
 			if (!watchedEl.siblings('.private-badge').length) {
 				const privateBadge = $('<span class="badge border border-gray-300 text-body private-badge ms-1"><i class="fa fa-lock"></i> Private</span>');

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -53,6 +53,9 @@ define('forum/category', [
 
 		new clipboard('[data-clipboard-text]');
 
+		// Add private badges to all topics with watching tags
+		addPrivateBadgesToTopics();
+
 		hooks.fire('action:topics.loaded', { topics: ajaxify.data.topics });
 		hooks.fire('action:category.loaded', { cid: ajaxify.data.cid });
 	};
@@ -149,6 +152,35 @@ define('forum/category', [
 		}, function (data, done) {
 			hooks.fire('action:topics.loaded', { topics: data.topics });
 			callback(data, done);
+		});
+	}
+
+	function addPrivateBadgesToTopics() {
+		console.log('addPrivateBadgesToTopics called');
+
+		// Add private badge to ALL topics for demo purposes
+		$('[component="category/topic"]').each(function() {
+			const topicEl = $(this);
+			const labelsContainer = topicEl.find('[component="topic/labels"]');
+
+			console.log('Processing topic, labels container found:', labelsContainer.length);
+
+			// Only add if badge doesn't already exist
+			if (labelsContainer.length && !labelsContainer.find('.private-badge').length) {
+				const privateBadge = $('<span class="badge border border-gray-300 text-body private-badge ms-1"><i class="fa fa-lock"></i> Private</span>');
+				labelsContainer.append(privateBadge);
+				console.log('Private badge added to topic');
+			}
+		});
+
+		// Also try adding to any visible watching badges
+		$('[component="topic/watched"]:visible').each(function() {
+			const watchedEl = $(this);
+			if (!watchedEl.siblings('.private-badge').length) {
+				const privateBadge = $('<span class="badge border border-gray-300 text-body private-badge ms-1"><i class="fa fa-lock"></i> Private</span>');
+				watchedEl.after(privateBadge);
+				console.log('Private badge added after watching badge');
+			}
 		});
 	}
 

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -77,6 +77,26 @@ define('forum/topic', [
 		hooks.fire('action:topic.loaded', ajaxify.data);
 	};
 
+	//attempt to put pivate toggle here
+
+	//<div class="composer-footer">
+	//   <button class="composer-hide">Hide</button>
+	//   <button class="composer-discard">Discard</button>
+
+	//   <label class="composer-private">
+	//     <input type="checkbox" id="private-toggle">
+	//     Private
+	//   </label>
+
+	//   <button class="composer-submit">Submit</button>
+	// </div>
+
+	// 	{{{ if topic.isPrivate }}}
+	// <span class="badge badge-warning">Private</span>
+	// {{{ end }}}
+
+
+
 	function handleTopicSearch() {
 		require(['mousetrap'], (mousetrap) => {
 			if (config.topicSearchEnabled) {
@@ -261,6 +281,35 @@ define('forum/topic', [
 		hooks.registerPage('action:posts.loaded', addCopyCodeButton);
 		hooks.registerPage('action:topic.loaded', addCopyCodeButton);
 		hooks.registerPage('action:posts.edited', addCopyCodeButton);
+
+		function addPrivateBadgeToTopicInfo() {
+			// Add private badge next to category and watching tags
+			console.log('addPrivateBadgeToTopicInfo called');
+
+			// Try multiple selectors to find the right place
+			let targetEl = $('.topic-info');
+			if (!targetEl.length) {
+				targetEl = $('[component="topic/title"]').parent();
+			}
+			if (!targetEl.length) {
+				targetEl = $('.topic-title').parent().parent();
+			}
+
+			console.log('Found target element:', targetEl.length);
+
+			// Only add if badge doesn't already exist
+			if (targetEl.length && !targetEl.find('.private-badge').length) {
+				const privateBadge = $('<span class="badge badge-warning private-badge ms-2">Private</span>');
+				targetEl.append(privateBadge);
+				console.log('Private badge added');
+			} else {
+				console.log('Badge already exists or no target element found');
+			}
+		}
+
+		hooks.registerPage('action:posts.loaded', addPrivateBadgeToTopicInfo);
+		hooks.registerPage('action:topic.loaded', addPrivateBadgeToTopicInfo);
+		hooks.registerPage('action:posts.edited', addPrivateBadgeToTopicInfo);
 	}
 
 	function addParentHandler() {

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -91,7 +91,7 @@ define('forum/topic', [
 	//   <button class="composer-submit">Submit</button>
 	// </div>
 
-	// 	{{{ if topic.isPrivate }}}
+	// {{{ if topic.isPrivate }}}
 	// <span class="badge badge-warning">Private</span>
 	// {{{ end }}}
 

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -94,4 +94,43 @@ exports.post = async function (req, res) {
 	} catch (err) {
 		helpers.noScriptErrors(req, res, err.message, 400);
 	}
+
+	//Private toggle attempt
+
+	// postContainer.find('#private-toggle').on('change', function () {
+	// 	composer.posts[post_uuid].isPrivate = this.checked;
+	//   });
+
+	// if (action === 'topics.post') {
+	// 	composerData = {
+	// 	  ...composerData,
+	// 	  handle: handleEl ? handleEl.val() : undefined,
+	// 	  title: titleEl.val(),
+	// 	  content: bodyEl.val(),
+	// 	  thumb: thumbEl.val() || '',
+	// 	  cid: categoryList.getSelectedCid(),
+	// 	  tags: tags.getTags(post_uuid),
+	// 	  timestamp: scheduler.getTimestamp(),
+	  
+	// 	  isPrivate: composer.posts[post_uuid].isPrivate || false,
+	// 	};
+	//   }
+
+	// if (action === 'topics.post') {
+	// 	composerData = {
+	// 	  ...composerData,
+	// 	  handle: handleEl ? handleEl.val() : undefined,
+	// 	  title: titleEl.val(),
+	// 	  content: bodyEl.val(),
+	// 	  thumb: thumbEl.val() || '',
+	// 	  cid: categoryList.getSelectedCid(),
+	// 	  tags: tags.getTags(post_uuid),
+	// 	  timestamp: scheduler.getTimestamp(),
+
+	// 	  isPrivate: composer.posts[post_uuid].isPrivate || false,
+	// 	};
+	//   }
+	  
+	  
+	  
 };

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -93,44 +93,5 @@ exports.post = async function (req, res) {
 		res.redirect(path);
 	} catch (err) {
 		helpers.noScriptErrors(req, res, err.message, 400);
-	}
-
-	//Private toggle attempt
-
-	// postContainer.find('#private-toggle').on('change', function () {
-	// composer.posts[post_uuid].isPrivate = this.checked;
-	//   });
-
-	// if (action === 'topics.post') {
-	// composerData = {
-	//   ...composerData,
-	//   handle: handleEl ? handleEl.val() : undefined,
-	//   title: titleEl.val(),
-	//   content: bodyEl.val(),
-	//   thumb: thumbEl.val() || '',
-	//   cid: categoryList.getSelectedCid(),
-	//   tags: tags.getTags(post_uuid),
-	//   timestamp: scheduler.getTimestamp(),
-
-	//   isPrivate: composer.posts[post_uuid].isPrivate || false,
-	// };
-	//   }
-
-	// if (action === 'topics.post') {
-	// composerData = {
-	//   ...composerData,
-	//   handle: handleEl ? handleEl.val() : undefined,
-	//   title: titleEl.val(),
-	//   content: bodyEl.val(),
-	//   thumb: thumbEl.val() || '',
-	//   cid: categoryList.getSelectedCid(),
-	//   tags: tags.getTags(post_uuid),
-	//   timestamp: scheduler.getTimestamp(),
-
-	//   isPrivate: composer.posts[post_uuid].isPrivate || false,
-	// };
-	//   }
-	  
-	  
-	  
+	}  
 };

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -98,37 +98,37 @@ exports.post = async function (req, res) {
 	//Private toggle attempt
 
 	// postContainer.find('#private-toggle').on('change', function () {
-	// 	composer.posts[post_uuid].isPrivate = this.checked;
+	// composer.posts[post_uuid].isPrivate = this.checked;
 	//   });
 
 	// if (action === 'topics.post') {
-	// 	composerData = {
-	// 	  ...composerData,
-	// 	  handle: handleEl ? handleEl.val() : undefined,
-	// 	  title: titleEl.val(),
-	// 	  content: bodyEl.val(),
-	// 	  thumb: thumbEl.val() || '',
-	// 	  cid: categoryList.getSelectedCid(),
-	// 	  tags: tags.getTags(post_uuid),
-	// 	  timestamp: scheduler.getTimestamp(),
-	  
-	// 	  isPrivate: composer.posts[post_uuid].isPrivate || false,
-	// 	};
+	// composerData = {
+	//   ...composerData,
+	//   handle: handleEl ? handleEl.val() : undefined,
+	//   title: titleEl.val(),
+	//   content: bodyEl.val(),
+	//   thumb: thumbEl.val() || '',
+	//   cid: categoryList.getSelectedCid(),
+	//   tags: tags.getTags(post_uuid),
+	//   timestamp: scheduler.getTimestamp(),
+
+	//   isPrivate: composer.posts[post_uuid].isPrivate || false,
+	// };
 	//   }
 
 	// if (action === 'topics.post') {
-	// 	composerData = {
-	// 	  ...composerData,
-	// 	  handle: handleEl ? handleEl.val() : undefined,
-	// 	  title: titleEl.val(),
-	// 	  content: bodyEl.val(),
-	// 	  thumb: thumbEl.val() || '',
-	// 	  cid: categoryList.getSelectedCid(),
-	// 	  tags: tags.getTags(post_uuid),
-	// 	  timestamp: scheduler.getTimestamp(),
+	// composerData = {
+	//   ...composerData,
+	//   handle: handleEl ? handleEl.val() : undefined,
+	//   title: titleEl.val(),
+	//   content: bodyEl.val(),
+	//   thumb: thumbEl.val() || '',
+	//   cid: categoryList.getSelectedCid(),
+	//   tags: tags.getTags(post_uuid),
+	//   timestamp: scheduler.getTimestamp(),
 
-	// 	  isPrivate: composer.posts[post_uuid].isPrivate || false,
-	// 	};
+	//   isPrivate: composer.posts[post_uuid].isPrivate || false,
+	// };
 	//   }
 	  
 	  

--- a/src/posts/category.js
+++ b/src/posts/category.js
@@ -43,4 +43,12 @@ module.exports = function (Posts) {
 		const isMembers = await db.isSortedSetMembers(`cid:${parseInt(cid, 10)}:pids`, pids);
 		return pids.filter((pid, index) => pid && isMembers[index]);
 	}
+
+	//<li class="topic-title">
+	//   <a href="{relative_path}/topic/{topics.slug}">{topics.title}</a>
+	//   {{{ if topics.isPrivate }}}
+	//     <span class="badge badge-warning">Private</span>
+	//   {{{ end }}}
+	// </li>
+
 };

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -28,6 +28,10 @@
 						<i class="fa fa-bell-o"></i>
 						<span>[[topic:watching]]</span>
 					</span>
+					<span class="badge border border-gray-300 text-body">
+						<i class="fa fa-lock"></i>
+						<span>Private</span>
+					</span>
 					<span component="topic/ignored" class="badge border border-gray-300 text-body {{{ if !./ignored }}}hidden{{{ end }}}">
 						<i class="fa fa-eye-slash"></i>
 						<span>[[topic:ignoring]]</span>


### PR DESCRIPTION
### Related Files
#42

### Context
Ensuring that users see a "Private" badge on their posts across multiple views. The tag provides clear visual feedback that a topic was created as private, and that only the admin (professor) can see these posts. This feature is especially important in an educational forum, where the ability to share information confidentially helps protect academic integrity while also giving students a safe space to ask questions comfortably.

### Description
This task will be accomplished in three sections:

1. Ensure that a "Private" badge is seen on all topic titles, across all relevant category pages (i.e. Announcements, General Discussion, Uncategorized, etc). 
2. "Private" badge is visible when viewing individual topic, topic in clicked into and expanded. 
3. "Private" badge appears on all relevant posts in the users Account page (page which details all posts the user has ever posted), allowing the user to differentiate between which of their posts were posted as private, and which were public.

### Changes in the codebase

** Have not yet integrated backend, so for demo purposes the UI currently shows badge on all topics, regardless if they were supposed to be private or not. UI has been successfully implemented when it can be verified that the "Private" badge appears in all intended places.

File changed - public/src/client/topic.js
- Updated hook registrations to call addPrivateBadgeToTopicInfo.
- Function now finds .topic-info container and appends a Private badge in the topic header.

File changed - public/src/client/category.js
- Added addPrivateBadgesToTopics to append Private badges on all topics in category, recent, and popular views.

File changed - vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
- Injected a <span> element with "Private" badge directly into the topic list template, ensuring badges always render on every topic header.

### Testing Steps
- Rebuilt NodeBB via ./nodebb build.
- Verified changes on:
- 1. Announcements category page, private badge appears next to Watching/Category labels.
- 2. Recent page, private badge visible on each topic.
- 3. Popular page, private badge visible on each topic.
- 4. User account page, private badge visible on all private topics.
- 5. Topic page, private badge is not visible on individual topic pages

### Testing Flow and Screenshots

In the "Recent", "Unread", and "Popular" pages, all posts the user has posted have "Private" badges on them, next to the "Watching" badge and "Categories" badge. It is noted that the "Welcome to you NodeBB" topic posted by the Admin also has a "Private" badge on the topic header, so this will need to be addressed when integrating the backend. 
<img width="1440" height="860" alt="Screenshot 2025-09-26 at 10 22 38 PM" src="https://github.com/user-attachments/assets/fe7c56d0-485f-443e-85d2-93b2a3c37208" />
We can see that the "Private" badge also shows consistently throughout all the category pages, such as the "Announcement" page shown here.
<img width="1440" height="859" alt="Screenshot 2025-09-26 at 11 33 59 AM" src="https://github.com/user-attachments/assets/d7973d18-a80c-4f95-8040-56f4266f60cb" />
After clicking into the topic post, "Private" badge is not visible on individual topic page. This section of the feature needs to be fixed.
<img width="1440" height="812" alt="Screenshot 2025-09-26 at 7 22 57 PM" src="https://github.com/user-attachments/assets/0ef8fd90-3d57-4e8b-8e59-f314cfec5ae9" />
Here in the Account page, we can see that topics that the user has created have "Private" badges on them, next to the "Watching" badge and "Categories" badge. 
<img width="1439" height="812" alt="Screenshot 2025-09-26 at 11 38 04 AM" src="https://github.com/user-attachments/assets/4648b477-5bcb-4457-9270-88e7e5d69591" />


### Additional information
Because the frontend and backend have not been integrated yet, the code is currently implemented to show the "Private" badge on all topics (for demo purposes). In Sprint 2 the front end logic will be integrated with backend and checks if a topic is actually private before rendering the badge.

All commits are linted, build runs successfully, and functionality verified locally.